### PR TITLE
Flip installer to use flags and reduce code duplication for missing scrolls

### DIFF
--- a/mod-caster-crafting/comp/missing-scrolls/component-install.tph
+++ b/mod-caster-crafting/comp/missing-scrolls/component-install.tph
@@ -1,0 +1,32 @@
+/******************************************************************
+*   Main installation entrypoint for missing scrolls component.   *
+*                                                                 *
+*   Expected variables populated:                                 *
+*       - ~bz-missing_scrolls-arcane~                             *
+*       -~bz-missing_scrolls-priest~                              *
+******************************************************************/
+
+ACTION_IF (~%bz-missing_scrolls-arcane%~) THEN
+BEGIN
+    PRINT ~Including Missing Arcane Scrolls~
+    INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/core/missing-arcane.tph~
+END
+
+
+ACTION_IF (~%bz-missing_scrolls-priest%~) THEN
+BEGIN
+    INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/core/missing-priest.tph~
+    ACTION_IF (%bz_iwdification_installed%)
+        BEGIN
+            PRINT ~Including Missing IWD-ification Divine Scrolls~
+            INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/iwdification/missing-priest.tph~
+        END
+    ACTION_IF (%bz_OlvynSpells_installed%)
+        BEGIN
+            PRINT ~Including Missing OlvynSpells Divine Scrolls~
+            INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/olvyn-spells/missing-priest.tph~
+        END
+END
+
+
+INCLUDE ~./%MOD_FOLDER%/comp/missing-scrolls/missing-scrolls.tph~

--- a/mod-caster-crafting/comp/missing-scrolls/component-install.tph
+++ b/mod-caster-crafting/comp/missing-scrolls/component-install.tph
@@ -3,7 +3,7 @@
 *                                                                 *
 *   Expected variables populated:                                 *
 *       - ~bz-missing_scrolls-arcane~                             *
-*       -~bz-missing_scrolls-priest~                              *
+*       - ~bz-missing_scrolls-priest~                             *
 ******************************************************************/
 
 ACTION_IF (~%bz-missing_scrolls-arcane%~) THEN

--- a/mod-caster-crafting/mod-caster-crafting.tp2
+++ b/mod-caster-crafting/mod-caster-crafting.tp2
@@ -41,39 +41,21 @@ LANGUAGE
 // Caster Crafting: Missing scrolls subcomponents
 BEGIN @11 DESIGNATED 11 // Add in missing arcane spell scrolls
 SUBCOMPONENT @10        //  Missing Spell Scrolls
-    INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/core/missing-arcane.tph~
-    INCLUDE ~./%MOD_FOLDER%/comp/missing-scrolls/missing-scrolls.tph~
+    OUTER_SET ~bz-missing_scrolls-arcane~ = 1
+    OUTER_SET ~bz-missing_scrolls-priest~ = 0
+    INCLUDE ~./%MOD_FOLDER%/comp/missing-scrolls/component-install.tph~
 
 BEGIN @12 DESIGNATED 12 // Add in missing priest spell scrolls
 SUBCOMPONENT @10        //  Missing Spell Scrolls
-    INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/core/missing-priest.tph~
-    ACTION_IF (%bz_iwdification_installed%)
-        BEGIN
-            PRINT ~DEBUG: Include Missing IWD-ification Scrolls~
-            INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/iwdification/missing-priest.tph~
-        END
-    ACTION_IF (%bz_OlvynSpells_installed%)
-        BEGIN
-            PRINT ~DEBUG: Include Missing OlvynSpells Scrolls~
-            INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/olvyn-spells/missing-priest.tph~
-        END
-    INCLUDE ~./%MOD_FOLDER%/comp/missing-scrolls/missing-scrolls.tph~
+    OUTER_SET ~bz-missing_scrolls-arcane~ = 0
+    OUTER_SET ~bz-missing_scrolls-priest~ = 1
+    INCLUDE ~./%MOD_FOLDER%/comp/missing-scrolls/component-install.tph~
 
 BEGIN @13 DESIGNATED 13 // Add in missing arcane and priest spell scrolls
 SUBCOMPONENT @10        //  Missing Spell Scrolls
-    INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/core/missing-arcane.tph~
-    INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/core/missing-priest.tph~
-    ACTION_IF (%bz_iwdification_installed%)
-        BEGIN
-            PRINT ~DEBUG: Include IWD-ification Spells~
-            INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/iwdification/missing-priest.tph~
-        END
-    ACTION_IF (%bz_OlvynSpells_installed%)
-        BEGIN
-            PRINT ~DEBUG: Include Missing OlvynSpells Scrolls~
-            INCLUDE ~./%MOD_FOLDER%/registration/scroll-lists/%bz_game_code%/olvyn-spells/missing-priest.tph~
-        END
-    INCLUDE ~./%MOD_FOLDER%/comp/missing-scrolls/missing-scrolls.tph~
+    OUTER_SET ~bz-missing_scrolls-arcane~ = 1
+    OUTER_SET ~bz-missing_scrolls-priest~ = 1
+    INCLUDE ~./%MOD_FOLDER%/comp/missing-scrolls/component-install.tph~
 //END Missing Scrolls
 
 


### PR DESCRIPTION
Use the flag setting pattern in the TP2 and a component-install script to reduce duplicated code