### PR TITLE
Exclude directories on Actions checkout steps (#93)

### DIFF
--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -19,8 +19,6 @@ jobs:
     permissions: write-all
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
 
     - name: Bump and Tag Version
       uses: jefflinse/pr-semver-bump@v1.7.4
@@ -76,6 +74,14 @@ jobs:
         uses: actions/checkout@master
         with:
           submodules: true
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            *
+            !.assets
+            !.research
+            !.markdown-assets
+            !.vs
+            !.vscode
 
       - name: Create Infinity Engine Mod Packages (.iemod and .zip)
         uses: ALIENQuake/CreateIEModZipPackage@master

--- a/.github/workflows/ci-pull-request-autoapprove-bot.yaml
+++ b/.github/workflows/ci-pull-request-autoapprove-bot.yaml
@@ -25,8 +25,6 @@ jobs:
     name: Validate Release Label and Notes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-        name: Checkout
 
       - uses: jefflinse/pr-semver-bump@v1.7.4
         id: semver
@@ -71,6 +69,15 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            *
+            !.assets
+            !.research
+            !.markdown-assets
+            !.vs
+            !.vscode
 
       - name: Create Infinity Engine Mod Packages (.iemod and .zip)
         uses: ALIENQuake/CreateIEModZipPackage@master


### PR DESCRIPTION
* Exclude certain directories from checkout to speed up checkout

* Exclude dirs on main that do not build the mod

* I don't think the first job job needs to even checkout, thinking about it...

* Address `Error: fatal: specify directories rather than patterns (no leading slash)`

* sparse-checkout-cone-mode: false

# Release Notes:
- Merge main into feature branch
- Clean up the checkout Actions and optimize jobs
<sub>_End Release Notes_</sub>